### PR TITLE
Affine almost equal comparison in load_targets

### DIFF
--- a/src/pyimpute/_main.py
+++ b/src/pyimpute/_main.py
@@ -116,7 +116,7 @@ def load_targets(explanatory_rasters):
             if not transform:
                 transform = src.transform
             else:
-                assert transform == src.transform
+                assert transform.almost_equals(src.transform)
 
             # Save or check the shape
             if not shape:


### PR DESCRIPTION
Should solve #24 by compensating for floating point precision limits between very similar transforms
